### PR TITLE
Add support for CO1200WIFI3

### DIFF
--- a/mill/__init__.py
+++ b/mill/__init__.py
@@ -538,6 +538,23 @@ class Heater:
         return self.sub_domain in [
             863,
         ]
+    
+    @property
+    def is_gen3(self):
+        """Check if heater is gen 3."""
+        return self.sub_domain in [
+            6980,
+        ]
+
+    @property
+    def generation(self):
+        """Get the generation of the heater."""
+        if (self.is_gen1):
+            return 1
+        elif (self.is_gen3):
+            return 3
+        else:
+            return 2
 
     @property
     def generation(self):
@@ -588,6 +605,7 @@ def set_heater_values(heater_data, heater):
     heater.tibber_control = heater_data.get("tibberControl")
     heater.open_window = heater_data.get("open_window", heater_data.get("open"))
     heater.is_heating = heater_data.get("heatStatus", heater_data.get("heaterFlag"))
+
     try:
         heater.sub_domain = int(
             float(
@@ -598,6 +616,10 @@ def set_heater_values(heater_data, heater):
         )
     except ValueError:
         pass
+    
+    # If the heater is a gen 3 the temprature reported is multiplied by 100
+    if (heater.is_gen3):
+        heater.set_temp = round(heater.set_temp / 100)
 
 
 @dataclass


### PR DESCRIPTION
Recently replaced my SG1200WIFI with a CO1200WIFI3. Found out this library does not work fully with it. 

It appears the mill app API provides the set temperature for this device multiplied by 100.
I have it configured in independent mode as I use my mill devices with home assistant.
The open window function is active and its temperature is set to 10 degrees with the room being 21.6 degrees.

I have added a property to identify if its a generation 3 heater, and I have updated the generation property to report accordingly. 

In the `set_heater_values` I have added a check if its gen 3 to divide the set temperature by 100.

So far I have only tested this in independent mode and not with the heater configured to a room.

Here is a dump of the data from the heater before these changes.

**Heater data**
```json
{
	"showBusinessLock": 0,
	"isHoliday": 0,
	"description": "",
	"holidayTemp": 1000,
	"deviceId": 1234567890,
	"deviceName": "Heater",
	"roomId": 1234567890,
	"deviceStatus": 0,
	"heaterFlag": 0,
	"powerStatus": 1,
	"times": "",
	"fanStatus": 0,
	"humidity": 0.0,
	"lock": 0,
	"deviceType": 1,
	"tvoc": 0,
	"fanStatusShow": 1,
	"showPreHeat": 0,
	"isManualControl": 0,
	"electricity": 0.0,
	"canChangeTemp": 1,
	"showOpen": 0,
	"preHeatStatus": 0,
	"eco2": 0,
	"subDomainId": 6980,
	"coolingStatus": 0,
	"currentTemp": 21.6,
	"showChildLock": 0,
	"open": 3
}
```

**Heater**
```python
Heater(
  device_id=1234567890,
  current_temp=21.6,
  device_status=0,
  available=True,
  name=Heater,
  fan_status=0,
  is_holiday=0,
  can_change_temp=1,
  set_temp=1000,
  power_status=1,
  tibber_control=None,
  open_window=3,
  is_heating=0,
  sub_domain=6980,
  home_id=1234567890
)
```