### PR TITLE
Use float for generation 3 heaters

### DIFF
--- a/mill/__init__.py
+++ b/mill/__init__.py
@@ -493,7 +493,7 @@ class Mill:
             payload = {
                 "subDomain": heater.sub_domain,
                 "deviceId": device_id,
-                "holdTemp": int(set_temp),
+                "holdTemp": float(set_temp),
             }
             if heater.independent_device:
                 payload["operation"] = "CHANGE_INDEPENDENT_TEMP"


### PR DESCRIPTION
Need to change from `int` to `float` for generation 3 heaters to be able to support 0.5 precision. I've made a [PR for it for Home Assistant](https://github.com/home-assistant/core/pull/73592), but had to revert the changes for cloud integration because of this.

No need to do this for [pyMillLocal](https://github.com/Danielhiversen/pyMillLocal) because there is no casting to int/float there.


https://user-images.githubusercontent.com/270292/182362354-f435cc52-623f-4726-8c35-c121a8039417.mov

Video of the result in Home Assistant ☝️ 
When changing the top one (cloud integration) it also updates the bottom one (local) after a few seconds. Had to change the mill integration in Home Assistant (see my [PR](https://github.com/home-assistant/core/pull/73592), but I reverted these changes because of the changes in this PR) to support 0.5 degrees.