### PR TITLE
Support both correct and multiplied temperatures

### DIFF
--- a/mill/__init__.py
+++ b/mill/__init__.py
@@ -25,6 +25,8 @@ API_ENDPOINT_STATS = "https://api.millheat.com/statistics/"
 DEFAULT_TIMEOUT = 10
 MIN_TIME_BETWEEN_STATS_UPDATES = dt.timedelta(minutes=10)
 REQUEST_TIMEOUT = "300"
+MIN_TEMP = 5
+MAX_TEMP = 35
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -645,7 +647,9 @@ def set_heater_values(heater_data, heater):
     if heater.independent_device or heater.is_holiday == 1:
         heater.set_temp = heater_data.get("holidayTemp")
         if heater.is_gen3 and heater.set_temp is not None and heater.independent_device:
-            heater.set_temp = round(heater.set_temp / 100)
+            divBy100 = heater.set_temp / 100
+            if heater.set_temp > MAX_TEMP and divBy100 >= MIN_TEMP:
+                heater.set_temp = round(divBy100, 1)
     elif heater.room is not None:
         if heater.room.current_mode == 1:
             heater.set_temp = heater.room.comfort_temp


### PR DESCRIPTION
When adding support for Gen3 heaters you mention the _holidayTemp_ is reported multiplied by 100.
I have such an heater, but the _holidayTemp_ is actually reported correct here, hence / 100 for me results in 0.0.
Therefore this pull-request to support both cases.

Verified working in devcontainer:
![image](https://user-images.githubusercontent.com/38791331/212764371-5e178ba5-13d4-4382-a704-10ca64ce8f19.png)

Here test code as proof for temperature range between MIN_TEMP and MAX_TEMP with 1 decimal resolution:
```python
# Dummy heater class
class Heater:
    def __init__(self, temp):
        self.set_temp = temp

    set_temp = 0
    is_gen3 = True
    independent_device = True


# Use fron const.py
MIN_TEMP = 5
MAX_TEMP = 35

# Generate range temperatures between MIN and MAX with 1 decimal
temperatures = [x / 10 for x in range(MIN_TEMP * 10, MAX_TEMP * 10 + 1)]
# Generate multiplied by 100
multipliedBy100 = [t * 100 for t in temperatures]
# Extend the list
temperatures.extend(multipliedBy100)

# Define translate function
def TranslateGen3Temp(temp):
    divBy100 = temp / 100
    if temp > MAX_TEMP and divBy100 >= MIN_TEMP:
        return round(divBy100, 1)
    return temp


# Loop over all temperatures
for temp in temperatures:
    heater = Heater(temp)

    if heater.is_gen3 and heater.set_temp is not None and heater.independent_device:
        heater.set_temp = TranslateGen3Temp(heater.set_temp)

    print(heater.set_temp)
```