### PR TITLE
Update install requirements

### DIFF
--- a/.github/workflows/code_checker.yml
+++ b/.github/workflows/code_checker.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install depencency
+      - name: Install dependency
         run: |
-            pip install aiohttp async_timeout
+            pip install aiohttp PyJWT
             pip install dlint flake8 flake8-bandit flake8-bugbear flake8-deprecated flake8-executable isort pylint
       - name: Flake8 Code Linter
         run: |

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="millheater",
     packages=["mill"],
-    install_requires=["aiohttp>=3.7.4,<4", "async_timeout>=3.0.0"],
+    install_requires=["aiohttp>=3.7.4,<4", "PyJWT>=2"],
     version="0.13.1",
     description="A python3 library to communicate with Mill",
     long_description="A python3 library to communicate with Mill",


### PR DESCRIPTION
The module no longer uses async_timeout, so drop it from install_requires and from the CI setup.

The code imports `jwt`, which is provided by the PyPI package PyJWT, so add that as a runtime dependency and install it in CI.